### PR TITLE
Update and add Nginx task definitions for EC2 and Fargate, respectively

### DIFF
--- a/nginx/nginx_ec2.json
+++ b/nginx/nginx_ec2.json
@@ -1,4 +1,7 @@
 {
+  "requiresCompatibilities": [
+    "EC2"
+  ],
   "containerDefinitions": [
     {
       "name": "nginx",

--- a/nginx/nginx_fargate.json
+++ b/nginx/nginx_fargate.json
@@ -1,0 +1,27 @@
+{
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "containerDefinitions": [
+    {
+      "name": "nginx",
+      "image": "nginx:latest",
+      "memory": "256",
+      "cpu": "256",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "logConfiguration": null
+    }
+  ],
+  "volumes": [],
+  "networkMode": "awsvpc",
+  "placementConstraints": [],
+  "family": "nginx",
+  "memory": "512",
+  "cpu": "256"
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
These changes update the existing Nginx task definition for EC2 and add a new Nginx task definition for Fargate.

- In case of EC2, the existing task definition does not work since a new field, `requiresCompatibilities`, is missed. The first commit adds this field and renames a file name in order to show its compatibility explicitly.
- The existing task definition cannot be reused for Fargate since `requiresCompatibilities` and `networkMode` should be `FARGATE` and `awsvpc`, respectively. Thus, the second commit creates a new definition for Fargate.

Please note that file name conventions are aligned with Kibana ones.

*Test*:
I tested these changes as ensuring that copying these JSON files into AWS ECS console successfully creates task definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
