### PR TITLE
Fix nginx task definition

### DIFF
--- a/nginx/nginx_ec2.json
+++ b/nginx/nginx_ec2.json
@@ -6,8 +6,8 @@
     {
       "name": "nginx",
       "image": "nginx:latest",
-      "memory": "256",
-      "cpu": "256",
+      "memory": 256,
+      "cpu": 256,
       "essential": true,
       "portMappings": [
         {

--- a/nginx/nginx_fargate.json
+++ b/nginx/nginx_fargate.json
@@ -6,8 +6,8 @@
     {
       "name": "nginx",
       "image": "nginx:latest",
-      "memory": "256",
-      "cpu": "256",
+      "memory": 256,
+      "cpu": 256,
       "essential": true,
       "portMappings": [
         {

--- a/nginx/nginx_fargate.json
+++ b/nginx/nginx_fargate.json
@@ -15,7 +15,14 @@
           "protocol": "tcp"
         }
       ],
-      "logConfiguration": null
+      "logConfiguration":{
+            "logDriver":"awslogs",
+            "options":{
+               "awslogs-group":"awslogs-nginx-ecs",
+               "awslogs-region":"us-east-1",
+               "awslogs-stream-prefix":"ecs"
+            }
+      }
     }
   ],
   "volumes": [],


### PR DESCRIPTION
*Issue #, if available:*

Current nginx task definition have two issues.

+ cpu and memory are string.They must be integer[1]
+ logConfiguration is not acceptable "null" 

```
$aws ecs register-task-definition --cli-input-json file://nginx_ec2.json
Parameter validation failed:
Invalid type for parameter containerDefinitions[0].memory, value: 256, type: <class 'str'>, valid types: <class 'int'>
Invalid type for parameter containerDefinitions[0].cpu, value: 256, type: <class 'str'>, valid types: <class 'int'>


aws ecs register-task-definition --cli-input-json file://nginx_fargate.json

Parameter validation failed:
Invalid type for parameter containerDefinitions[0].memory, value: 256, type: <class 'str'>, valid types: <class 'int'>
Invalid type for parameter containerDefinitions[0].cpu, value: 256, type: <class 'str'>, valid types: <class 'int'>
Invalid type for parameter containerDefinitions[0].logConfiguration, value: None, type: <class 'NoneType'>, valid types: <class 'dict'>
```

*Description of changes:*

+ Change cpu and memory from string to integer
+ Set logconfiguration in fargate task definition


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[1]https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_environment