### PR TITLE
Remove hostPort

### DIFF
--- a/tomcat/tomcat_fargate.json
+++ b/tomcat/tomcat_fargate.json
@@ -11,7 +11,6 @@
       },
       "portMappings": [
         {
-          "hostPort": 8080,
           "protocol": "tcp",
           "containerPort": 8080
         }


### PR DESCRIPTION
`hostPort` must not be provided when using FARGATE mode.
https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-containers-to-aws-fargate/

*Description of changes:*
When using Fargate, `hostPort` should not be specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
